### PR TITLE
'id' field was added when getting documents

### DIFF
--- a/FirestoreDocument.js
+++ b/FirestoreDocument.js
@@ -35,6 +35,12 @@ function getFieldsFromFirestoreDocument_(firestoreDoc) {
     const keys = Object.keys(fields);
     const object = {};
 
+    var path = firestoreDoc["name"];
+    if (path) {
+      var id = getIdFromPath_(path);
+      object["id"] = id;
+    }
+
     for (var i = 0; i < keys.length; i++) {
         var key = keys[i];
         var firestoreValue = fields[key];


### PR DESCRIPTION
the same function is used to parse map fields, in that case, the id is not necessary.
if an 'id' field exists in a map field it will be overridden by the map field 'id' value, as expected.