### PR TITLE
Add Query Functionality

### DIFF
--- a/Delete.js
+++ b/Delete.js
@@ -1,5 +1,5 @@
 /* eslint no-unused-vars: ["error", { "varsIgnorePattern": "_" }] */
-/* global UrlFetchApp, checkForError_, getObjectFromResponse_ */
+/* global fetchObject_ */
 
 /**
  * Delete the Firestore document at the given path.
@@ -18,8 +18,5 @@ function deleteDocument_ (pathToDocument, authToken, projectId) {
     'headers': {'content-type': 'application/json', 'Authorization': 'Bearer ' + authToken}
   }
 
-  var responseObj = getObjectFromResponse_(UrlFetchApp.fetch(baseUrl, options))
-  checkForError_(responseObj)
-
-  return responseObj
+  return fetchObject_(baseUrl, options)
 }

--- a/Firestore.js
+++ b/Firestore.js
@@ -1,5 +1,5 @@
 /* eslint no-unused-vars: ["error", { "varsIgnorePattern": "_|Fire|get" }] */
-/* globals createDocument_, createDocumentWithId_, deleteDocument_, getAuthToken_, getDocument_, getDocuments_, getDocumentIds_, updateDocument_ */
+/* globals createDocument_, createDocumentWithId_, deleteDocument_, getAuthToken_, getDocument_, getDocuments_, getDocumentIds_, query_, updateDocument_ */
 
 /**
  * Get an object that acts as an authenticated interface with a Firestore project.
@@ -25,7 +25,7 @@ var Firestore = function (email, key, projectId) {
   /**
    * The authentication token used for accessing Firestore.
    */
-  const authToken = getAuthToken_(email, key)
+  const authToken = getAuthToken_(email, key, 'https://www.googleapis.com/oauth2/v4/token/')
 
   /**
    * Create a document with the given ID and fields.
@@ -100,10 +100,10 @@ var Firestore = function (email, key, projectId) {
    * @return {object} the JSON response from the GET request
    */
   this.query = function () {
-    const from = Array.prototype.slice.call(arguments);
-    return query_(from, authToken, projectId);
+    const from = Array.prototype.slice.call(arguments)
+    return query_(from, authToken, projectId)
   }
-  
+
   /**
    * Delete the Firestore document at the given path.
    * Note: this deletes ONLY this document, and not any subcollections.

--- a/Firestore.js
+++ b/Firestore.js
@@ -96,10 +96,10 @@ var Firestore = function (email, key, projectId) {
    *  return an all the documents that match the query.
    * Must call .execute() to send the request.
    *
-   * @param {string} path to check (can be repeated any number of times)
+   * @param {...string} path to check (can be repeated any number of times)
    * @return {object} the JSON response from the GET request
    */
-  this.query = function () {
+  this.query = function (path) {
     const from = Array.prototype.slice.call(arguments)
     return query_(from, authToken, projectId)
   }

--- a/Firestore.js
+++ b/Firestore.js
@@ -23,81 +23,94 @@ function getFirestore (email, key, projectId) {
  */
 var Firestore = function (email, key, projectId) {
   /**
-     * The authentication token used for accessing Firestore.
-     */
+   * The authentication token used for accessing Firestore.
+   */
   const authToken = getAuthToken_(email, key)
 
   /**
-     * Create a document with the given ID and fields.
-     *
-     * @param {string} documentId the document's ID in Firestore
-     * @param {string} path the path where the document will be written
-     * @param {object} fields the document's fields
-     * @return {object} the Document object written to Firestore
-     */
+   * Create a document with the given ID and fields.
+   *
+   * @param {string} documentId the document's ID in Firestore
+   * @param {string} path the path where the document will be written
+   * @param {object} fields the document's fields
+   * @return {object} the Document object written to Firestore
+   */
   this.createDocumentWithId = function (documentId, path, fields) {
     return createDocumentWithId_(path, documentId, fields, authToken, projectId)
   }
 
   /**
-     * Create a document with the given fields and an auto-generated ID.
-     *
-     * @param {string} path the path where the document will be written
-     * @param {object} fields the document's fields
-     * @return {object} the Document object written to Firestore
-     */
+   * Create a document with the given fields and an auto-generated ID.
+   *
+   * @param {string} path the path where the document will be written
+   * @param {object} fields the document's fields
+   * @return {object} the Document object written to Firestore
+   */
   this.createDocument = function (path, fields) {
     return createDocument_(path, fields, authToken, projectId)
   }
 
   /**
-     * Update/patch a document at the given path with new fields.
-     *
-     * @param {string} path the path of the document to update
-     * @param {object} fields the document's new fields
-     * @return {object} the Document object written to Firestore
-     */
+   * Update/patch a document at the given path with new fields.
+   *
+   * @param {string} path the path of the document to update
+   * @param {object} fields the document's new fields
+   * @return {object} the Document object written to Firestore
+   */
   this.updateDocument = function (path, fields) {
     return updateDocument_(path, fields, authToken, projectId)
   }
 
   /**
-     * Get a list of all documents in a collection.
-     *
-     * @param {string} pathToCollection the path to the collection
-     * @return {object} an array of the documents in the collection
-     */
+   * Get a list of all documents in a collection.
+   *
+   * @param {string} pathToCollection the path to the collection
+   * @return {object} an array of the documents in the collection
+   */
   this.getDocuments = function (pathToCollection) {
     return getDocuments_(pathToCollection, authToken, projectId)
   }
 
   /**
-     * Get a document.
-     *
-     * @param {string} path the path to the document
-     * @return {object} the document object
-     */
+   * Get a document.
+   *
+   * @param {string} path the path to the document
+   * @return {object} the document object
+   */
   this.getDocument = function (path) {
     return getDocument_(path, authToken, projectId)
   }
 
   /**
-     * Get a list of all IDs of the documents in a collection.
-     *
-     * @param {string} pathToCollection the path to the collection
-     * @return {object} an array of IDs of the documents in the collection
-     */
+   * Get a list of all IDs of the documents in a collection.
+   *
+   * @param {string} pathToCollection the path to the collection
+   * @return {object} an array of IDs of the documents in the collection
+   */
   this.getDocumentIds = function (pathToCollection) {
     return getDocumentIds_(pathToCollection, authToken, projectId)
   }
 
   /**
-     * Delete the Firestore document at the given path.
-     * Note: this deletes ONLY this document, and not any subcollections.
-     *
-     * @param {string} pathToDocument the path to the document to delete
-     * @return {object} the JSON response from the DELETE request
-     */
+   * Run a query against the Firestore Database and
+   *  return an all the documents that match the query.
+   * Must call .execute() to send the request.
+   *
+   * @param {string} path to check (can be repeated any number of times)
+   * @return {object} the JSON response from the GET request
+   */
+  this.query = function () {
+    const from = Array.prototype.slice.call(arguments);
+    return query_(from, authToken, projectId);
+  }
+  
+  /**
+   * Delete the Firestore document at the given path.
+   * Note: this deletes ONLY this document, and not any subcollections.
+   *
+   * @param {string} pathToDocument the path to the document to delete
+   * @return {object} the JSON response from the DELETE request
+   */
   this.deleteDocument = function (pathToDocument) {
     return deleteDocument_(pathToDocument, authToken, projectId)
   }

--- a/FirestoreDocument.js
+++ b/FirestoreDocument.js
@@ -8,18 +8,14 @@
  */
 function createFirestoreDocument_ (fields) {
   const keys = Object.keys(fields)
-  const firestoreObj = {}
-
-  firestoreObj['fields'] = {}
+  const fieldsObj = {}
 
   for (var i = 0; i < keys.length; i++) {
     var key = keys[i]
-    var val = fields[key]
-
-    firestoreObj['fields'][key] = wrapValue_(val)
+    fieldsObj[key] = wrapValue_(fields[key])
   }
 
-  return firestoreObj
+  return {fields: fieldsObj}
 }
 
 /**
@@ -56,8 +52,7 @@ function wrapValue_ (value) {
       return wrapNumber_(value)
     case 'boolean':
       return wrapBoolean_(value)
-    default:
-      // error
+    default: // error
       return null
   }
 }

--- a/Query.js
+++ b/Query.js
@@ -1,0 +1,172 @@
+/* eslint no-unused-vars: ["error", { "varsIgnorePattern": "_" }] */
+/* globals IsNumeric_, wrapValue_ */
+
+/**
+ * An object that acts as a Query to be a structured query.
+ *
+ * @class
+ * @private
+ * @see {@link https://firebase.google.com/docs/firestore/reference/rest/v1beta1/StructuredQuery Firestore Structured Query}
+ * @param {string} from the base collection to query
+ * @param {string} callback the function that is executed with the internally compiled query
+ */
+var FirestoreQuery_ = function (from, callback) {
+  const this_ = this
+
+  // @see {@link https://firebase.google.com/docs/firestore/reference/rest/v1beta1/StructuredQuery#Operator_1 FieldFilter Operator}
+  const fieldOps = {
+    '==': 'EQUAL',
+    '===': 'EQUAL',
+    '<': 'LESS_THAN',
+    '<=': 'LESS_THAN_OR_EQUAL',
+    '>': 'GREATER_THAN',
+    '>=': 'GREATER_THAN_OR_EQUAL'
+  }
+
+  // @see {@link https://firebase.google.com/docs/firestore/reference/rest/v1beta1/StructuredQuery#Operator_2 FieldFilter Operator}
+  const unaryOps = {
+    'nan': 'IS_NAN',
+    'null': 'IS_NULL'
+  }
+
+  // @see {@link https://firebase.google.com/docs/firestore/reference/rest/v1beta1/StructuredQuery#FieldReference Field Reference}
+  const fieldRef = function (field) {
+    return {fieldPath: field}
+  }
+  const filter = function (field, operator, value) {
+    // @see {@link https://firebase.google.com/docs/firestore/reference/rest/v1beta1/StructuredQuery#FieldFilter Field Filter}
+    if (operator in fieldOps) {
+      return {
+        fieldFilter: {
+          field: fieldRef(field),
+          op: fieldOps[operator],
+          value: wrapValue_(value)
+        }
+      }
+    }
+
+    // @see {@link https://firebase.google.com/docs/firestore/reference/rest/v1beta1/StructuredQuery#UnaryFilter Unary Filter}
+    if (operator.toLowerCase() in unaryOps) {
+      return {
+        unaryFilter: {
+          field: fieldRef(field),
+          op: unaryOps[operator]
+        }
+      }
+    }
+    throw new Error('Invalid Operator given ' + operator)
+  }
+
+  const query = {
+    from: from.map(function (collection) {
+      return {
+        collectionId: collection
+      }
+    })
+  }
+
+  /**
+   * Select Query which can narrow which fields to return.
+   *  Can be repeated if multiple fields are needed in the response.
+   *
+   * @see {@link https://firebase.google.com/docs/firestore/reference/rest/v1beta1/StructuredQuery#Projection Select}
+   * @param {string} field The field to narrow down (if empty, returns name of document)
+   * @returns {object} this query object for chaining
+   */
+  this.select = function (field) {
+    if (!query.select) {
+      query.select = {fields: []}
+    }
+    if (!field || !field.trim()) { // Catch undefined or blank strings
+      field = '__name__'
+    }
+
+    query.select.fields.push(fieldRef(field))
+    return this_
+  }
+
+  /**
+   * Filter Query by a given field and operator (or additionally a value).
+   *  Can be repeated if multiple filters required.
+   *  Results must satisfy all filters.
+   *
+   * @param {string} field The field to reference for filtering
+   * @param {string} operator The operator to filter by. {@link fieldOps} {@link unaryOps}
+   * @param {?number|?string|?array|?object} value Object to set the field value to. Null if using a unary operator.
+   * @returns {object} this query object for chaining
+   */
+  this.where = function (field, operator, value) {
+    if (query.where) {
+      if (!query.where.compositeFilter) {
+        query.where = {
+          compositeFilter: {
+            op: 'AND', // Currently "OR" is unsupported
+            filters: [
+              query.where
+            ]
+          }
+        }
+      }
+      query.where.compositeFilter.filters.push(filter(field, operator, value))
+    } else {
+      query.where = filter(field, operator, value)
+    }
+    return this_
+  }
+
+  /**
+   * Orders the Query results based on a field and specific direction.
+   *  Can be repeated if additional ordering is needed.
+   *
+   * @see {@link https://firebase.google.com/docs/firestore/reference/rest/v1beta1/StructuredQuery#Projection Select}
+   * @param {string} field The field to order by.
+   * @param {string} dir The direction to order the field by. Should be one of "asc" or "desc". Defaults to Ascending.
+   * @returns {object} this query object for chaining
+   */
+  this.orderBy = function (field, dir) {
+    if (!query.orderBy) {
+      query.orderBy = []
+    }
+    dir = (dir && (dir.substr(0, 3).toUpperCase() === 'DEC' || dir.substr(0, 4).toUpperCase() === 'DESC')) ? 'DESCENDING' : 'ASCENDING'
+
+    query.orderBy.push({
+      field: fieldRef(field),
+      direction: dir
+    })
+    return this_
+  }
+
+  /**
+   * Offsets the Query results by a given number of documents.
+   *
+   * @param {number} offset Number of results to skip
+   * @returns {object} this query object for chaining
+   */
+  this.offset = function (offset) {
+    if (!IsNumeric_(offset)) { throw new TypeError('Offset is not a valid number!') }
+    query.offset = offset
+    return this_
+  }
+
+  /**
+   * Limits the amount Query results returned.
+   *
+   * @param {number} limit Number of results limit
+   * @returns {object} this query object for chaining
+   */
+  this.limit = function (limit) {
+    if (!IsNumeric_(limit)) { throw new TypeError('Limit is not a valid number!') }
+    query.limit = limit
+    return this_
+  }
+
+  /**
+   * Executes the query with the given callback method and the generated query.
+   *  Must be used at the end of any query for execution.
+   *
+   * @returns {object} The query results from the execution
+   */
+  this.execute = function () {
+    return callback(query) // Not using callback.bind due to debugging limitations of GAS
+  }
+}

--- a/Query.js
+++ b/Query.js
@@ -1,5 +1,14 @@
 /* eslint no-unused-vars: ["error", { "varsIgnorePattern": "_" }] */
-/* globals IsNumeric_, wrapValue_ */
+/* globals isNumeric_, wrapValue_ */
+
+/**
+ * This callback type is called `queryCallback`.
+ *  Callback should utilize the Query parameter to send a request and return the response.
+ *
+ * @callback queryCallback
+ * @param {object} query the Structured Query to utilize in the query request {@link FirestoreQuery_}
+ * @returns [object] response of the sent query
+ */
 
 /**
  * An object that acts as a Query to be a structured query.
@@ -7,8 +16,8 @@
  * @class
  * @private
  * @see {@link https://firebase.google.com/docs/firestore/reference/rest/v1beta1/StructuredQuery Firestore Structured Query}
- * @param {string} from the base collection to query
- * @param {string} callback the function that is executed with the internally compiled query
+ * @param {string[]} from the base collection to query
+ * @param {queryCallback} callback the function that is executed with the internally compiled query
  */
 var FirestoreQuery_ = function (from, callback) {
   const this_ = this
@@ -92,7 +101,7 @@ var FirestoreQuery_ = function (from, callback) {
    *
    * @param {string} field The field to reference for filtering
    * @param {string} operator The operator to filter by. {@link fieldOps} {@link unaryOps}
-   * @param {?number|?string|?array|?object} value Object to set the field value to. Null if using a unary operator.
+   * @param {*} [value] Object to set the field value to. Null if using a unary operator.
    * @returns {object} this query object for chaining
    */
   this.where = function (field, operator, value) {
@@ -143,7 +152,9 @@ var FirestoreQuery_ = function (from, callback) {
    * @returns {object} this query object for chaining
    */
   this.offset = function (offset) {
-    if (!IsNumeric_(offset)) { throw new TypeError('Offset is not a valid number!') }
+    if (!isNumeric_(offset)) {
+      throw new TypeError('Offset is not a valid number!')
+    }
     query.offset = offset
     return this_
   }
@@ -155,7 +166,9 @@ var FirestoreQuery_ = function (from, callback) {
    * @returns {object} this query object for chaining
    */
   this.limit = function (limit) {
-    if (!IsNumeric_(limit)) { throw new TypeError('Limit is not a valid number!') }
+    if (!isNumeric_(limit)) {
+      throw new TypeError('Limit is not a valid number!')
+    }
     query.limit = limit
     return this_
   }

--- a/Read.js
+++ b/Read.js
@@ -144,7 +144,7 @@ function getDocument_ (path, authToken, projectId) {
  * Set up a Query to receive data from a collection
  *
  * @private
- * @param {string} from the path to the document or collection to get
+ * @param {string[]} from the path to the document or collection to get
  * @param {string} authToken an authentication token for reading from Firestore
  * @param {string} projectId the Firestore project ID
  * @return {object} A FirebaseQuery object to set up the query and eventually execute

--- a/Read.js
+++ b/Read.js
@@ -165,10 +165,10 @@ function query_ (from, authToken, projectId) {
 
     const documents = responseObj.reduce(function (docs, fireDoc) {
       if (fireDoc.document) {
-        var doc = getFieldsFromFirestoreDocument_(fireDoc.document)
-        if (doc) {
-          docs.push(doc)
+        if (fireDoc.document.fields) {
+          fireDoc.document.fields = getFieldsFromFirestoreDocument_(fireDoc.document)
         }
+        docs.push(fireDoc.document)
       }
       return docs
     }, [])

--- a/Read.js
+++ b/Read.js
@@ -1,23 +1,31 @@
 /* eslint no-unused-vars: ["error", { "varsIgnorePattern": "_" }] */
-/* globals UrlFetchApp, addAll_, checkForError_, getFieldsFromFirestoreDocument_, getIdFromPath_, getObjectFromResponse_ */
+/* globals UrlFetchApp, FirestoreQuery_, addAll_, checkForError_, getFieldsFromFirestoreDocument_, getIdFromPath_, getObjectFromResponse_ */
 
 /**
- * Get the Firestore document or collection at a given path. If the collection
- *  contains enough IDs to return a paginated result, this method only
- *  returns the first page.
+ * Get the Firestore document or collection at a given path.
+ *  If the collection contains enough IDs to return a paginated result,
+ *  this method only returns the first page.
  *
+ * @private
  * @param {string} path the path to the document or collection to get
  * @param {string} authToken an authentication token for reading from Firestore
  * @param {string} projectId the Firestore project ID
  * @return {object} the JSON response from the GET request
  */
 function get_ (path, authToken, projectId) {
-  return getPage_(path, projectId, authToken, null)
+  return getPage_(path, projectId, authToken)
 }
 
 /**
  * Get a page of results from the given path. If null pageToken
  *  is supplied, returns first page.
+ *
+ * @private
+ * @param {string} path the path to the document or collection to get
+ * @param {string} authToken an authentication token for reading from Firestore
+ * @param {string} projectId the Firestore project ID
+ * @param {string} pageToken if defined, is utilized for retrieving subsequent pages
+ * @return {object} the JSON response from the GET request
  */
 function getPage_ (path, projectId, authToken, pageToken) {
   var baseUrl = 'https://firestore.googleapis.com/v1beta1/projects/' + projectId + '/databases/(default)/documents/' + path
@@ -44,6 +52,7 @@ function getPage_ (path, projectId, authToken, pageToken) {
  *  types). This is a helper method, not meant to return documents to a user of the
  *  library.
  *
+ * @private
  * @param {string} pathToCollection the path to the collection
  * @param {string} authToken an authentication token for reading from Firestore
  * @param {string} projectId the Firestore project ID
@@ -51,13 +60,10 @@ function getPage_ (path, projectId, authToken, pageToken) {
  */
 function getDocumentResponsesFromCollection_ (pathToCollection, authToken, projectId) {
   const initialResponse = get_(pathToCollection, authToken, projectId)
-  checkForError_(initialResponse)
-
-  if (!initialResponse['documents']) {
+  const documentResponses = initialResponse['documents']
+  if (!documentResponses) {
     return []
   }
-
-  const documentResponses = initialResponse['documents']
 
   // Get all pages of results if there are multiple
   var pageResponse = initialResponse
@@ -70,13 +76,13 @@ function getDocumentResponsesFromCollection_ (pathToCollection, authToken, proje
       addAll_(documentResponses, pageResponse['documents'])
     }
   }
-
   return documentResponses
 }
 
 /**
  * Get a list of all IDs of the documents in a collection.
  *
+ * @private
  * @param {string} pathToCollection the path to the collection
  * @param {string} authToken an authentication token for reading from Firestore
  * @param {string} projectId the Firestore project ID
@@ -84,7 +90,6 @@ function getDocumentResponsesFromCollection_ (pathToCollection, authToken, proje
  */
 function getDocumentIds_ (pathToCollection, authToken, projectId) {
   const documentResponses = getDocumentResponsesFromCollection_(pathToCollection, authToken, projectId)
-
   const ids = []
 
   // Create ID list from documents
@@ -101,6 +106,7 @@ function getDocumentIds_ (pathToCollection, authToken, projectId) {
 /**
  * Get a list of all documents in a collection.
  *
+ * @private
  * @param {string} pathToCollection the path to the collection
  * @param {string} authToken an authentication token for reading from Firestore
  * @param {string} projectId the Firestore project ID
@@ -108,7 +114,6 @@ function getDocumentIds_ (pathToCollection, authToken, projectId) {
  */
 function getDocuments_ (pathToCollection, authToken, projectId) {
   const documentResponses = getDocumentResponsesFromCollection_(pathToCollection, authToken, projectId)
-
   const documents = []
 
   for (var i = 0; i < documentResponses.length; i++) {
@@ -123,6 +128,7 @@ function getDocuments_ (pathToCollection, authToken, projectId) {
 /**
  * Get a document.
  *
+ * @private
  * @param {string} path the path to the document
  * @param {string} authToken an authentication token for reading from Firestore
  * @param {string} projectId the Firestore project ID
@@ -130,23 +136,58 @@ function getDocuments_ (pathToCollection, authToken, projectId) {
  */
 function getDocument_ (path, authToken, projectId) {
   const doc = get_(path, authToken, projectId)
-  checkForError_(doc)
-
   if (!doc['fields']) {
     throw new Error('No document with `fields` found at path ' + path)
   }
 
   doc.fields = getFieldsFromFirestoreDocument_(doc)
-
   return doc
+}
+/**
+ * Set up a Query to receive data from a collection
+ *
+ * @private
+ * @param {string} from the path to the document or collection to get
+ * @param {string} authToken an authentication token for reading from Firestore
+ * @param {string} projectId the Firestore project ID
+ * @return {object} A FirebaseQuery object to set up the query and eventually execute
+ */
+function query_ (from, authToken, projectId) {
+  var baseUrl = 'https://firestore.googleapis.com/v1beta1/projects/' + projectId + '/databases/(default)/documents:runQuery'
+  const options = {
+    'method': 'post',
+    'muteHttpExceptions': true,
+    'headers': {'content-type': 'application/json', 'Authorization': 'Bearer ' + authToken}
+  }
+
+  const callback = function (query) {
+    options.payload = JSON.stringify({
+      structuredQuery: query
+    })
+    const responseObj = getObjectFromResponse_(UrlFetchApp.fetch(baseUrl, options))
+    checkForError_(responseObj)
+
+    const documents = responseObj.reduce(function (docs, fireDoc) {
+      if (fireDoc.document) {
+        var doc = getFieldsFromFirestoreDocument_(fireDoc.document)
+        if (doc) {
+          docs.push(doc)
+        }
+      }
+      return docs
+    }, [])
+
+    return documents
+  }
+  return new FirestoreQuery_(from, callback)
 }
 
 /**
  * Unwrap the given document response's fields.
  *
+ * @private
  * @param docResponse the document response
  * @return the document response, with unwrapped fields
- * @private
  */
 function unwrapDocumentFields_ (docResponse) {
   docResponse.fields = getFieldsFromFirestoreDocument_(docResponse)

--- a/Read.js
+++ b/Read.js
@@ -1,5 +1,5 @@
 /* eslint no-unused-vars: ["error", { "varsIgnorePattern": "_" }] */
-/* globals UrlFetchApp, FirestoreQuery_, addAll_, checkForError_, getFieldsFromFirestoreDocument_, getIdFromPath_, getObjectFromResponse_ */
+/* globals FirestoreQuery_, addAll_, getFieldsFromFirestoreDocument_, getIdFromPath_, fetchObject_ */
 
 /**
  * Get the Firestore document or collection at a given path.
@@ -39,10 +39,7 @@ function getPage_ (path, projectId, authToken, pageToken) {
     options['pageToken'] = pageToken
   }
 
-  var responseObj = getObjectFromResponse_(UrlFetchApp.fetch(baseUrl, options))
-  checkForError_(responseObj)
-
-  return responseObj
+  return fetchObject_(baseUrl, options)
 }
 
 /**
@@ -164,8 +161,7 @@ function query_ (from, authToken, projectId) {
     options.payload = JSON.stringify({
       structuredQuery: query
     })
-    const responseObj = getObjectFromResponse_(UrlFetchApp.fetch(baseUrl, options))
-    checkForError_(responseObj)
+    const responseObj = fetchObject_(baseUrl, options)
 
     const documents = responseObj.reduce(function (docs, fireDoc) {
       if (fireDoc.document) {

--- a/Util.js
+++ b/Util.js
@@ -12,6 +12,10 @@ function isInt_ (n) {
   return n % 1 === 0
 }
 
+function IsNumeric_ (val) {
+  return Number(parseFloat(val)) === val
+}
+
 function base64EncodeSafe_ (string) {
   const encoded = Utilities.base64EncodeWebSafe(string)
   return encoded.replace(/=/g, '')
@@ -34,6 +38,9 @@ function getObjectFromResponse_ (response) {
 function checkForError_ (responseObj) {
   if (responseObj['error']) {
     throw new Error(responseObj['error']['message'])
+  }
+  if (Array.isArray(responseObj) && responseObj.length && responseObj[0]['error']) {
+    throw new Error(responseObj[0]['error']['message'])
   }
 }
 

--- a/Util.js
+++ b/Util.js
@@ -12,7 +12,7 @@ function isInt_ (n) {
   return n % 1 === 0
 }
 
-function IsNumeric_ (val) {
+function isNumeric_ (val) {
   return Number(parseFloat(val)) === val
 }
 

--- a/Util.js
+++ b/Util.js
@@ -1,5 +1,5 @@
 /* eslint no-unused-vars: ["error", { "varsIgnorePattern": "_" }] */
-/* globals Utilities */
+/* globals UrlFetchApp, Utilities */
 
 // RegEx test for root path references
 var regexPath_ = /^projects\/.+?\/databases\/\(default\)\/documents\/.+\/.+$/
@@ -25,14 +25,16 @@ function removeTrailingSlash_ (string) {
   const length = string.length
   if (string.charAt(length - 1) === '/') {
     // Remove trailing slash
-    return string.substr(0, length - 1)
-  } else {
-    return string
+    string = string.substr(0, length - 1)
   }
+  return string
 }
 
-function getObjectFromResponse_ (response) {
-  return JSON.parse(response.getContentText())
+function fetchObject_ (url, options) {
+  const response = UrlFetchApp.fetch(url, options)
+  const responseObj = JSON.parse(response.getContentText())
+  checkForError_(responseObj)
+  return responseObj
 }
 
 function checkForError_ (responseObj) {

--- a/Write.js
+++ b/Write.js
@@ -1,9 +1,10 @@
 /* eslint no-unused-vars: ["error", { "varsIgnorePattern": "_" }] */
-/* globals UrlFetchApp, checkForError_, createFirestoreDocument_, getObjectFromResponse_, removeTrailingSlash_ */
+/* globals createFirestoreDocument_, fetchObject_, removeTrailingSlash_ */
 
 /**
  * Create a document with the given ID and fields.
  *
+ * @private
  * @param {string} path the path where the document will be written
  * @param {string} documentId the document's ID in Firestore
  * @param {object} fields the document's fields
@@ -27,17 +28,13 @@ function createDocumentWithId_ (path, documentId, fields, authToken, projectId) 
     'headers': {'content-type': 'application/json', 'Authorization': 'Bearer ' + authToken}
   }
 
-  const response = UrlFetchApp.fetch(baseUrl, options)
-  const responseObj = getObjectFromResponse_(response)
-
-  checkForError_(responseObj)
-
-  return responseObj
+  return fetchObject_(baseUrl, options)
 }
 
 /**
  * Create a document with the given fields and an auto-generated ID.
  *
+ * @private
  * @param {string} path the path where the document will be written
  * @param {object} fields the document's fields
  * @param {string} authToken an authentication token for writing to Firestore
@@ -51,6 +48,7 @@ function createDocument_ (path, fields, authToken, projectId) {
 /**
  * Update/patch a document at the given path with new fields.
  *
+ * @private
  * @param {string} path the path of the document to update
  * @param {object} fields the document's new fields
  * @param {string} authToken an authentication token for writing to Firestore
@@ -68,9 +66,5 @@ function updateDocument_ (path, fields, authToken, projectId) {
     'headers': {'content-type': 'application/json', 'Authorization': 'Bearer ' + authToken}
   }
 
-  const response = UrlFetchApp.fetch(baseUrl, options)
-  const responseObj = getObjectFromResponse_(response)
-  checkForError_(responseObj)
-
-  return responseObj
+  return fetchObject_(baseUrl, options)
 }


### PR DESCRIPTION
* Set up runQuery functionality. #25
* Added JSDoc comments and minor cleanup. #21
  Matched the style of `wrapArray_()` to `createFirestoreDocument_()`

To use:
```javascript
var db = FirestoreApi.getFirestore(email, key, project);
var path = "string/to/collection", //Required.
    fieldname = "nameOfFieldToFilter",
    operator = "==", //Can be ==, ===, <, <=, >, >=, NaN, or null (the last 2 don't need a value)
    value = "valueToCheck",
    dir = "asc"; //Direction can be asc, ascending, desc, dec, descending. Defaults to ascending.
var results = db.query(path).where(fieldname, operator, value).orderBy(fieldname, dir).offset(0).limit(20).execute();
```

All chained methods between `query()` and `execute()` (not inclusive) are optional.
Multiple paths can be searched. i.e. `db.query(path1, path2, path3, etc...)`

The [Wiki](https://github.com/grahamearley/FirestoreGoogleAppsScript/wiki) will also need to be updated if this gets merged in.