### PR TITLE
Fix issue when trying to unwrap an empty Array

### DIFF
--- a/FirestoreDocument.js
+++ b/FirestoreDocument.js
@@ -176,6 +176,6 @@ function wrapArray_ (array) {
 }
 
 function unwrapArray_ (wrappedArray) {
-  const array = wrappedArray.map(unwrapValue_)
+  const array = (wrappedArray || []).map(unwrapValue_)
   return array
 }


### PR DESCRIPTION
Self titled to address #30.

Empty Objects are already covered by https://github.com/grahamearley/FirestoreGoogleAppsScript/pull/31/commits/94587a1adb8b8c5bb1c04e45f782737f91df5574#diff-f6f4e897c16a2f1205515ca8dfc6768eL27