### PR TITLE
Allow Query Filter values of null, undefined, or NaN

### DIFF
--- a/Query.js
+++ b/Query.js
@@ -46,11 +46,17 @@ var FirestoreQuery_ = function (from, callback) {
   const filter = function (field, operator, value) {
     // @see {@link https://firebase.google.com/docs/firestore/reference/rest/v1beta1/StructuredQuery#FieldFilter Field Filter}
     if (operator in fieldOps) {
-      return {
-        fieldFilter: {
-          field: fieldRef(field),
-          op: fieldOps[operator],
-          value: wrapValue_(value)
+      if (value == null) { // Covers null and undefined values
+        operator = 'null'
+      } else if (isNaN(value)) { // Covers NaN
+        operator = 'nan'
+      } else {
+        return {
+          fieldFilter: {
+            field: fieldRef(field),
+            op: fieldOps[operator],
+            value: wrapValue_(value)
+          }
         }
       }
     }


### PR DESCRIPTION
I thought issue #32 brought up a good point, so I added a quick change to allow null/undefined/NaN values to be checked if a value being searched uses it.

This would allow `.query().where(field, "==", undefined/null)` be equivalent to `.query().where(field, "null")` and respectively `.query().where(field, "==", NaN)` be equivalent to `.query().where(field, "NaN")`.