### PR TITLE
Use safer NaN check in query code

### DIFF
--- a/Query.js
+++ b/Query.js
@@ -48,7 +48,7 @@ var FirestoreQuery_ = function (from, callback) {
     if (operator in fieldOps) {
       if (value == null) { // Covers null and undefined values
         operator = 'null'
-      } else if (isNaN(value)) { // Covers NaN
+      } else if (isNumberNaN(value)) { // Covers NaN
         operator = 'nan'
       } else {
         return {

--- a/Util.js
+++ b/Util.js
@@ -57,3 +57,14 @@ function getColDocFromPath_ (path, isDocument) {
   // Remainder of path is in splitPath. Put back together and return.
   return [splitPath.join('/'), item]
 }
+
+/**
+ * Check if a value is of type Number but is NaN.
+ *  This check prevents seeing non-numeric values as NaN.
+ *
+ * @param {value} the value to check
+ * @returns {boolean} whether the given value is of type number and equal to NaN
+ */
+function isNumberNaN(value) {
+  return typeof(value) == "number" && isNaN(value)
+}


### PR DESCRIPTION
This PR fixes #37 by adding a safer `NaN` check that first checks whether the value is of type `number` and then whether the value `isNaN`.

Note: I had to add an extra util method to do this, since it seems like `Number.isNaN` is not available in Google Apps Script.