### PR TITLE
Added updateMask Parameter to updateDocument_

### DIFF
--- a/Firestore.js
+++ b/Firestore.js
@@ -79,11 +79,12 @@ var Firestore = function (email, key, projectId) {
    * @param {string} path the path of the document to update.
    *                      If document name not provided, a random ID will be generated.
    * @param {object} fields the document's new fields
+   * @param {boolean} if true, the update will use a mask
    * @return {object} the Document object written to Firestore
    */
-  this.updateDocument = function (path, fields) {
+  this.updateDocument = function (path, fields, mask) {
     const request = new FirestoreRequest_(baseUrl, authToken)
-    return updateDocument_(path, fields, request)
+    return updateDocument_(path, fields, request, mask)
   }
 
   /**

--- a/Write.js
+++ b/Write.js
@@ -33,8 +33,8 @@ function createDocument_ (path, fields, request) {
  */
 function updateDocument_ (path, fields, request) {
   const firestoreObject = createFirestoreDocument_(fields)
-  Object.keys(fields).forEach(function(field){
+  for(field in fields){
     request.addParam('updateMask.fieldPaths',field)
-  });
+  }
   return request.patch(path, firestoreObject)
 }

--- a/Write.js
+++ b/Write.js
@@ -29,13 +29,21 @@ function createDocument_ (path, fields, request) {
  * @param {string} path the path of the document to update
  * @param {object} fields the document's new fields
  * @param {string} request the Firestore Request object to manipulate
+ * @param {boolean} if true, the update will use a mask
  * @return {object} the Document object written to Firestore
  */
-function updateDocument_ (path, fields, request) {
+function updateDocument_ (path, fields, request, mask) {  
+  if (mask) {
+    // abort request if fields object is empty
+    if (!Object.keys(fields).length) {
+      return;
+    }
+    for (field in fields) {
+      request.addParam('updateMask.fieldPaths', field)
+    }
+  }
+
   const firestoreObject = createFirestoreDocument_(fields)
   
-  for (field in fields) {
-    request.addParam('updateMask.fieldPaths', field)
-  }
   return request.patch(path, firestoreObject)
 }

--- a/Write.js
+++ b/Write.js
@@ -33,8 +33,9 @@ function createDocument_ (path, fields, request) {
  */
 function updateDocument_ (path, fields, request) {
   const firestoreObject = createFirestoreDocument_(fields)
-  for(field in fields){
-    request.addParam('updateMask.fieldPaths',field)
+  
+  for (field in fields) {
+    request.addParam('updateMask.fieldPaths', field)
   }
   return request.patch(path, firestoreObject)
 }

--- a/Write.js
+++ b/Write.js
@@ -33,5 +33,8 @@ function createDocument_ (path, fields, request) {
  */
 function updateDocument_ (path, fields, request) {
   const firestoreObject = createFirestoreDocument_(fields)
+  Object.keys(fields).forEach(function(field){
+    request.addParam('updateMask.fieldPaths',field)
+  });
   return request.patch(path, firestoreObject)
 }


### PR DESCRIPTION
Loops through the keys in the `fields` variable and adds them to the parameters with `request.addParam('updateMask.fieldPaths',field)`

In response to issue #23: Allow updateMask to be set for Patch/Updating documents 
