### PR TITLE
Missing ARRAY_CONTAINS operator

### DIFF
--- a/Query.js
+++ b/Query.js
@@ -31,7 +31,7 @@ var FirestoreQuery_ = function (from, callback) {
     '<=': 'LESS_THAN_OR_EQUAL',
     '>': 'GREATER_THAN',
     '>=': 'GREATER_THAN_OR_EQUAL',
-    'array-contains': 'ARRAY_CONTAINS'
+    'contains': 'ARRAY_CONTAINS'
   }
 
   // @see {@link https://firebase.google.com/docs/firestore/reference/rest/v1beta1/StructuredQuery#Operator_2 FieldFilter Operator}

--- a/Query.js
+++ b/Query.js
@@ -30,7 +30,8 @@ var FirestoreQuery_ = function (from, callback) {
     '<': 'LESS_THAN',
     '<=': 'LESS_THAN_OR_EQUAL',
     '>': 'GREATER_THAN',
-    '>=': 'GREATER_THAN_OR_EQUAL'
+    '>=': 'GREATER_THAN_OR_EQUAL',
+    'array-contains': 'ARRAY_CONTAINS'
   }
 
   // @see {@link https://firebase.google.com/docs/firestore/reference/rest/v1beta1/StructuredQuery#Operator_2 FieldFilter Operator}


### PR DESCRIPTION
Can you please add the ARRAY_CONTAINS operator?
https://firebase.google.com/docs/firestore/reference/rest/v1beta1/StructuredQuery#Operator_1

I haven't tested but it I think you just need to add it to the fieldOps.

#45 