### PR TITLE
Allow using custom masks to update nested fields

### DIFF
--- a/FirestoreWrite.ts
+++ b/FirestoreWrite.ts
@@ -49,7 +49,7 @@ class FirestoreWrite {
         throw new Error('Missing fields in Mask!');
       }
       for (const field of maskData) {
-        request.addParam('updateMask.fieldPaths', `\`${field.replace(/`/g, '\\`')}\``);
+        request.addParam('updateMask.fieldPaths', `${field.replace(/`/g, '\\`')}`);
       }
     }
 

--- a/FirestoreWrite.ts
+++ b/FirestoreWrite.ts
@@ -48,15 +48,8 @@ class FirestoreWrite {
       if (!maskData.length) {
         throw new Error('Missing fields in Mask!');
       }
-
-      if (typeof mask === 'boolean') {
-        for (const field of maskData) {
-          request.addParam('updateMask.fieldPaths', `\`${field.replace(/`/g, '\\`')}\``);
-        }
-      } else {
-        for (const field of maskData) {
-          request.addParam('updateMask.fieldPaths', field);
-        }
+      for (const field of maskData) {
+        request.addParam('updateMask.fieldPaths', `\`${field.replace(/`/g, '\\`')}\``);
       }
     }
 

--- a/FirestoreWrite.ts
+++ b/FirestoreWrite.ts
@@ -48,8 +48,15 @@ class FirestoreWrite {
       if (!maskData.length) {
         throw new Error('Missing fields in Mask!');
       }
-      for (const field of maskData) {
-        request.addParam('updateMask.fieldPaths', `\`${field.replace(/`/g, '\\`')}\``);
+
+      if (typeof mask === 'boolean') {
+        for (const field of maskData) {
+          request.addParam('updateMask.fieldPaths', `\`${field.replace(/`/g, '\\`')}\``);
+        }
+      } else {
+        for (const field of maskData) {
+          request.addParam('updateMask.fieldPaths', field);
+        }
       }
     }
 


### PR DESCRIPTION
Fix #146 Unable to update nested fields with custome mask in updateDocument()

The user can choose update a nested field with mask like<pre lang='js'>['field3.field4']</pre>
Or update a field with '.' (dot) in its name with mask quoted by \` like <pre lang='js'>['\`field3.field4\`']</pre> 