### PR TITLE
Support updating nested fields with dot notation

### DIFF
--- a/Firestore.ts
+++ b/Firestore.ts
@@ -96,11 +96,12 @@ class Firestore implements FirestoreRead, FirestoreWrite, FirestoreDelete {
    * @param {boolean|string[]} mask if true, the update will mask the given fields,
    * if is an array (of field names), that array would be used as the mask.
    * (that way you can, for example, include a field in `mask`, but not in `fields`, and by doing so, delete that field)
+   * @param {boolean} nestedField support nested field name
    * @return {object} the Document object written to Firestore
    */
-  updateDocument(path: string, fields: Record<string, any>, mask?: boolean | string[]): Document {
+  updateDocument(path: string, fields: Record<string, any>, mask?: boolean | string[], nestedField?: boolean): Document {
     const request = new Request(this.baseUrl, this.authToken);
-    return this.updateDocument_(path, fields, request, mask);
+    return this.updateDocument_(path, fields, request, mask, nestedField);
   }
 
   updateDocument_ = FirestoreWrite.prototype.updateDocument_;

--- a/FirestoreWrite.ts
+++ b/FirestoreWrite.ts
@@ -56,7 +56,7 @@ class FirestoreWrite {
         }
       } else {
         for (const field of maskData) {
-          if (field.includes('`')) {
+          if (field.includes('.')) {
             request.addParam('updateMask.fieldPaths', `\`${field.replace(/`/g, '\\`')}\``);
           } else {
             request.addParam('updateMask.fieldPaths', `${field}`);

--- a/FirestoreWrite.ts
+++ b/FirestoreWrite.ts
@@ -56,11 +56,7 @@ class FirestoreWrite {
         }
       } else {
         for (const field of maskData) {
-          if (field.includes('.')) {
-            request.addParam('updateMask.fieldPaths', `\`${field.replace(/`/g, '\\`')}\``);
-          } else {
-            request.addParam('updateMask.fieldPaths', `${field}`);
-          }
+          request.addParam('updateMask.fieldPaths', `\`${field.replace(/`/g, '\\`')}\``);
         }
       }
     }

--- a/FirestoreWrite.ts
+++ b/FirestoreWrite.ts
@@ -33,9 +33,10 @@ class FirestoreWrite {
    * @param {boolean|string[]} mask the update will mask the given fields,
    * if is an array (of field names), that array would be used as the mask. i.e. true: updates only specific fields, false: overwrites document with specified fields
    * see jsdoc of the `updateDocument` method in Firestore.ts for more details
+   * @param {boolean} nestedField support nested field name
    * @return {object} the Document object written to Firestore
    */
-  updateDocument_(path: string, fields: Record<string, any>, request: Request, mask?: boolean | string[]): Document {
+  updateDocument_(path: string, fields: Record<string, any>, request: Request, mask?: boolean | string[], nestedField?: boolean): Document {
     if (mask) {
       const maskData = typeof mask === 'boolean' ? Object.keys(fields) : mask;
 
@@ -48,12 +49,19 @@ class FirestoreWrite {
       if (!maskData.length) {
         throw new Error('Missing fields in Mask!');
       }
-      for (const field of maskData) {
-        request.addParam('updateMask.fieldPaths', `\`${field.replace(/`/g, '\\`')}\``);
+
+      if (nestedField == true) {
+        for (const field of maskData) {
+          request.addParam('updateMask.fieldPaths', `${field}`);
+        }
+      } else {
+        for (const field of maskData) {
+          request.addParam('updateMask.fieldPaths', `\`${field.replace(/`/g, '\\`')}\``);
+        }
       }
     }
 
-    const firestoreObject = new Document(fields);
+    const firestoreObject = new Document(fields, undefined, nestedField);
     const updatedDoc = request.patch<FirestoreAPI.Document>(path, firestoreObject);
     return new Document(updatedDoc, {} as Document);
   }

--- a/FirestoreWrite.ts
+++ b/FirestoreWrite.ts
@@ -56,7 +56,11 @@ class FirestoreWrite {
         }
       } else {
         for (const field of maskData) {
-          request.addParam('updateMask.fieldPaths', `\`${field.replace(/`/g, '\\`')}\``);
+          if (field.includes('`')) {
+            request.addParam('updateMask.fieldPaths', `\`${field.replace(/`/g, '\\`')}\``);
+          } else {
+            request.addParam('updateMask.fieldPaths', `${field}`);
+          }
         }
       }
     }

--- a/Tests.ts
+++ b/Tests.ts
@@ -206,6 +206,69 @@ class Tests implements TestManager {
     GSUnit.assertObjectEquals(expected, updatedDoc.obj);
   }
 
+  Test_Update_Document_Nested_Field() {
+    const path = 'Test Collection/Update Document Nested Field';
+    const original = {
+      'org number value': -100,
+      'org string value 이': 'The fox jumps over the lazy dog 름',
+    };
+    this.db.createDocument(path, original);
+    const updater = {'field.subField': 'value'};
+    const expected = {field: {subField: 'value'}};
+    const updatedDoc = this.db.updateDocument(path, updater, undefined, true);
+    GSUnit.assertEquals(path, updatedDoc.path);
+    GSUnit.assertObjectEquals(expected, updatedDoc.obj);
+  }
+
+  Test_Update_Document_Mask_Nested_Field() {
+    const path = 'Test Collection/Update Document Mask Nested Field';
+    const original = {
+      'org number value': -100,
+      'org string value 이': 'The fox jumps over the lazy dog 름',
+    };
+    this.db.createDocument(path, original);
+    const updater = {
+      'field.subField1': 'value1',
+      'field.subField2': 'value2',
+    };
+    const mask = true;
+    const expected = {
+      'org number value': -100,
+      'org string value 이': 'The fox jumps over the lazy dog 름',
+      field: {
+        subField1: 'value1',
+        subField2: 'value2',
+      }
+    };
+    const updatedDoc = this.db.updateDocument(path, updater, mask, true);
+    GSUnit.assertEquals(path, updatedDoc.path);
+    GSUnit.assertObjectEquals(expected, updatedDoc.obj);
+  }
+
+  Test_Update_Document_Mask_Array_Nested_Field() {
+    const path = 'Test Collection/Update Document Mask Array Nested Field';
+    const original = {
+      'org number value': -100,
+      'org string value 이': 'The fox jumps over the lazy dog 름',
+    };
+    this.db.createDocument(path, original);
+    const updater = {
+      'field.subField1': 'value1',
+      'field.subField2': 'value2',
+    };
+    const mask = ['field.subField2'];
+    const expected = {
+      'org number value': -100,
+      'org string value 이': 'The fox jumps over the lazy dog 름',
+      field: {
+        subField2: 'value2',
+      }
+    };
+    const updatedDoc = this.db.updateDocument(path, updater, mask, true);
+    GSUnit.assertEquals(path, updatedDoc.path);
+    GSUnit.assertObjectEquals(expected, updatedDoc.obj);
+  }
+
   Test_Get_Document(): void {
     const path = 'Test Collection/New Document !@#$%^&*(),.<>?;\':"[]{}|-=_+áéíóúæÆÑ';
     const doc = this.db.getDocument(path);
@@ -228,7 +291,7 @@ class Tests implements TestManager {
   Test_Get_Documents(): void {
     const path = 'Test Collection';
     const docs = this.db.getDocuments(path);
-    GSUnit.assertEquals(8, docs.length);
+    GSUnit.assertEquals(12, docs.length);
     const doc = docs.find((doc) => doc.name!.endsWith('/New Document !@#$%^&*(),.<>?;\':"[]{}|-=_+áéíóúæÆÑ'));
     GSUnit.assertNotUndefined(doc);
     GSUnit.assertObjectEquals(this.expected_, doc!.obj);
@@ -242,6 +305,9 @@ class Tests implements TestManager {
       'Updatable Document Overwrite',
       'Updatable Document Mask',
       'Missing Document',
+      'Update Document Nested Field',
+      'Update Document Mask Nested Field',
+      'Update Document Mask Array Nested Field',
     ];
     const docs = this.db.getDocuments(path, ids);
     GSUnit.assertEquals(ids.length - 1, docs.length);
@@ -255,6 +321,9 @@ class Tests implements TestManager {
       'Updatable Document Overwrite',
       'Updatable Document Mask',
       'Missing Document',
+      'Update Document Nested Field',
+      'Update Document Mask Nested Field',
+      'Update Document Mask Array Nested Field',
     ];
     const docs = this.db.getDocuments(path, ids);
     GSUnit.assertEquals(0, docs.length);
@@ -270,7 +339,7 @@ class Tests implements TestManager {
   Test_Get_Document_IDs(): void {
     const path = 'Test Collection';
     const docs = this.db.getDocumentIds(path);
-    GSUnit.assertEquals(8, docs.length);
+    GSUnit.assertEquals(12, docs.length);
   }
 
   Test_Get_Document_IDs_Missing(): void {
@@ -295,19 +364,19 @@ class Tests implements TestManager {
   Test_Query_Select_Name(): void {
     const path = 'Test Collection';
     const docs = this.db.query(path).Select().Execute();
-    GSUnit.assertEquals(8, docs.length);
+    GSUnit.assertEquals(12, docs.length);
   }
 
   Test_Query_Select_Name_Number(): void {
     const path = 'Test Collection';
     const docs = this.db.query(path).Select().Select('number value').Execute();
-    GSUnit.assertEquals(8, docs.length);
+    GSUnit.assertEquals(12, docs.length);
   }
 
   Test_Query_Select_String(): void {
     const path = 'Test Collection';
     const docs = this.db.query(path).Select('string value 이').Execute();
-    GSUnit.assertEquals(8, docs.length);
+    GSUnit.assertEquals(12, docs.length);
   }
 
   Test_Query_Where_EqEq_String(): void {
@@ -475,7 +544,7 @@ class Tests implements TestManager {
   Test_Query_Offset(): void {
     const path = 'Test Collection';
     const docs = this.db.query(path).Offset(2).Execute();
-    GSUnit.assertEquals(6, docs.length);
+    GSUnit.assertEquals(10, docs.length);
   }
 
   Test_Query_Limit(): void {

--- a/Util.ts
+++ b/Util.ts
@@ -148,4 +148,36 @@ class Util_ {
       .map(([k, v]) => `${process(k)}=${process(v)}`)
       .join('&');
   }
+
+  /**
+   * Simple object check.
+   * @param item
+   * @returns {boolean}
+   */
+  static isObject(item: any) {
+    return (item && typeof item === 'object' && !Array.isArray(item));
+  }
+
+  /**
+   * Deep merge two objects.
+   * @param target
+   * @param ...sources
+   */
+  static mergeDeep(target: any, ...sources: any): any {
+    if (!sources.length) return target;
+    const source = sources.shift();
+
+    if (this.isObject(target) && this.isObject(source)) {
+      for (const key in source) {
+        if (this.isObject(source[key])) {
+          if (!target[key]) Object.assign(target, { [key]: {} });
+          this.mergeDeep(target[key], source[key]);
+        } else {
+          Object.assign(target, { [key]: source[key] });
+        }
+      }
+    }
+
+    return this.mergeDeep(target, ...sources);
+  }
 }


### PR DESCRIPTION
Fix #146  Unable to update nested fields with custome mask in updateDocument()
1. Add a flag 'nestedField' in updateDocument() to control if treating fields with dot notation as nested fields or single fields. If it is not set or set to false, the library will keep the original behaviour.
2. Fields in the updater will be merged based on their inserted order
3. Add  3 new tests to for the new flag